### PR TITLE
typo fixed recieve > receive lib.rs

### DIFF
--- a/monad-eth-txpool-ipc/src/lib.rs
+++ b/monad-eth-txpool-ipc/src/lib.rs
@@ -159,7 +159,7 @@ impl EthTxPoolIpcClient {
         let snapshot_bytes = stream.next().await.ok_or_else(|| {
             io::Error::new(
                 ErrorKind::InvalidData,
-                "EthTxPoolIpcClient must recieve snapshot on connectino",
+                "EthTxPoolIpcClient must receive snapshot on connectino",
             )
         })??;
 


### PR DESCRIPTION
A few typos. #2118
File : monad-eth-txpool-ipc > src > lib.rs
line 162 : EthTxPoolIpcClient must receive snapshot on connection recieve > receive